### PR TITLE
feat (nav): add scaffolding for statistics banner

### DIFF
--- a/src/app/components/StatisticsBanner/Banner.tsx
+++ b/src/app/components/StatisticsBanner/Banner.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+export function Banner() {
+  return (
+    <>
+      <StatList>
+        <StatListItem>
+          <P>TVL</P>
+          <P2>187.07k ꜩ</P2>
+        </StatListItem>
+        <StatListItem>
+          <P>Total Volume</P>
+          <P2>2.82M ꜩ</P2>
+        </StatListItem>
+        <StatListItem>
+          <P>Total Transactions</P>
+          <P2>122,723</P2>
+        </StatListItem>
+      </StatList>
+    </>
+  );
+}
+
+// const P = styled.p`
+//   margin: 0.625rem 0 1.5rem 0;
+//   color: ${p => p.theme.textSecondary};
+//   user-select: none;
+//   text-decoration: none;
+//   display: flex;
+//   font-size: 0.875rem;
+//   font-weight: 500;
+// `;
+
+const P = styled.p`
+  margin: 0;
+  color: ${p => p.theme.textSecondary};
+  user-select: none;
+  text-decoration: none;
+  display: flex;
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  &.active {
+    opacity: 1;
+  }
+`;
+
+const P2 = styled(P)`
+  cursor: pointer;
+  color: #b8b8b8;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:active {
+    opacity: 0.4;
+  }
+`;
+
+const StatList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: inline-flex;
+`;
+
+const StatItem = styled.a`
+  color: ${p => p.theme.textSecondary};
+  cursor: pointer;
+  text-decoration: none;
+  display: flex;
+  font-size: 0.875rem;
+  font-weight: 500;
+  align-items: center;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:active {
+    opacity: 0.4;
+  }
+
+  .light {
+    color: white;
+  }
+`;
+
+const StatListItem = styled.li`
+  display: inline-flex;
+  margin-right: 10px;
+  gap: 5px;
+  text-align: center;
+`;

--- a/src/app/components/StatisticsBanner/index.tsx
+++ b/src/app/components/StatisticsBanner/index.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import styled from 'styled-components/macro';
+import { Banner } from './Banner';
+
+export function StatisticsBanner() {
+  return (
+    <Wrapper>
+      <Banner />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 5rem;
+`;

--- a/src/app/pages/Swap/index.tsx
+++ b/src/app/pages/Swap/index.tsx
@@ -5,6 +5,7 @@ import { SwapWidget } from './components/SwapWidget';
 import styled from 'styled-components';
 import { StyleConstants } from 'styles/StyleConstants';
 import { NavBar } from 'app/components/NavBar';
+import { StatisticsBanner } from 'app/components/StatisticsBanner';
 
 const Wrapper = styled(PageWrapper)`
   height: calc(100vh - ${StyleConstants.NAV_BAR_HEIGHT});
@@ -24,6 +25,7 @@ export function Swap() {
         />
       </Helmet>
       <NavBar />
+      <StatisticsBanner />
       <Wrapper>
         <SwapWidget />
       </Wrapper>


### PR DESCRIPTION
- providers necessary components to display salsadao and tezos ecosystem stats under the navbar.