### PR TITLE
feat: improve first load

### DIFF
--- a/src/app/common/const.ts
+++ b/src/app/common/const.ts
@@ -1,4 +1,5 @@
 import { DAppClientOptions, NetworkType } from '@airgap/beacon-sdk';
+import { SpicyToken } from 'types/SpicyToken';
 
 /* todo: refactor into one global config object for easy access and import */
 
@@ -20,5 +21,16 @@ export const dappOptions: DAppClientOptions = {
 
 export const defaultPairList: string[] = [
   'KT1PnUZCp3u2KzWr93pn4DD7HAJnm3rWVrgn:0',
-  'KT1K4jn23GonEmZot3pMGth7unnzZ6EaMVjY:0',
 ];
+
+export const defaultFrom: SpicyToken = {
+  decimals: 6,
+  derivedUsd: 1.244648989805831,
+  derivedXtz: 1,
+  img: 'ipfs://bafybeidwsid6fvv4vxbqja7er3b4exsht5r7umv6hpz7rc3ujg7xilhwv4',
+  name: 'WTZ',
+  symbol: 'WTZ',
+  tag: 'KT1PnUZCp3u2KzWr93pn4DD7HAJnm3rWVrgn:0',
+  totalLiquidityUsd: 92874.1649167061,
+  totalLiquidityXtz: 74618.76053199123,
+};

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -12,7 +12,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import { GlobalStyle } from 'styles/global-styles';
 
-import { Swap } from './pages/Swap/Loadable';
+import { Swap } from './pages/Swap/';
 import { useTranslation } from 'react-i18next';
 import { NftMarketplace } from './pages/NftMarketplace/Loadable';
 import { NavBar } from './components/NavBar';

--- a/src/app/pages/Swap/components/SwapSelection/index.tsx
+++ b/src/app/pages/Swap/components/SwapSelection/index.tsx
@@ -15,8 +15,7 @@ import { useSpicySwapSlice } from '../../slice';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectFromAmount, selectToAmount } from '../../slice/selectors';
 import { ChangeEvent, useEffect } from 'react';
-import { getSwapQuote } from '../../util/price';
-
+import { getSwapAmount } from '../../util/price';
 interface SwapAssetSelectionProps {
   toggleModal: (dir?: SwapDirection) => void;
   pair?: SwapPair;
@@ -34,41 +33,15 @@ export function SwapAssetSelection({
   const fromAmount = useSelector(selectFromAmount);
   const toAmount = useSelector(selectToAmount);
 
-  const formatAmount = (value: number | undefined) => (value ? value : '');
-
   const handleTokenClick = (dir: SwapDirection) => {
     toggleModal(dir);
   };
 
-  const getSwapAmount = (pair, fromAmount) => {
-    const tokenFrom =
-      pair.pool.fromToken.tag === pair.from?.tag
-        ? pair.pool.fromToken
-        : pair.pool.toToken;
-
-    const tokenTo =
-      pair.pool.toToken.tag === pair.to?.tag
-        ? pair.pool.toToken
-        : pair.pool.fromToken;
-
-    const tokenFromReserve = Number(tokenFrom.reserve);
-    const tokenToReserve = Number(tokenTo.reserve);
-
-    return getSwapQuote({
-      tokenFromReserve,
-      tokenToReserve,
-      tokenFromAmount: fromAmount,
-    });
-  };
+  const formatAmount = (value: number | undefined) => (value ? value : '');
 
   const handleFromAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
     const fromInputValue = Number(event.target.value);
     dispatch(actions.setFromAmount(fromInputValue));
-
-    if (pair && pair.pool) {
-      const toAmount = getSwapAmount(pair, fromInputValue);
-      dispatch(actions.setToAmount(toAmount));
-    }
   };
 
   const handleToAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -77,11 +50,15 @@ export function SwapAssetSelection({
   };
 
   useEffect(() => {
-    if (pair && pair.pool && fromAmount) {
-      const toAmount = getSwapAmount(pair, fromAmount);
+    if (pair && pair.pool) {
+      const { toAmount, priceImpact } = getSwapAmount({
+        pair,
+        fromAmount,
+      });
+
       dispatch(actions.setToAmount(toAmount));
     }
-  }, [pair]);
+  }, [pair, fromAmount]);
 
   return (
     <>
@@ -97,11 +74,11 @@ export function SwapAssetSelection({
               <>
                 <SwapSelectionTokenIcon url={pair.from.img} />
                 {pair.from.symbol}
+                <SwapSelectionArrowIcon />
               </>
             ) : (
-              'Select Token'
+              <></>
             )}
-            <SwapSelectionArrowIcon />
           </SwapSelectionAsset>
         </A>
         <TitleText>Balance: 1212.22</TitleText>

--- a/src/app/pages/Swap/components/SwapWidget/index.tsx
+++ b/src/app/pages/Swap/components/SwapWidget/index.tsx
@@ -126,18 +126,20 @@ export function SwapWidget({
           </PriceImpact>
         </SwapSubsection>
       </Wrapper>
-      <Modal
-        show={modalView}
-        onClick={() => {
-          toggleModal();
-        }}
-      >
-        <SwapTokenList
-          toggleModal={toggleModal}
-          tokens={tokens}
-          setPair={setPair}
-        />
-      </Modal>
+      {modalView && (
+        <Modal
+          show={modalView}
+          onClick={() => {
+            toggleModal();
+          }}
+        >
+          <SwapTokenList
+            toggleModal={toggleModal}
+            tokens={tokens}
+            setPair={setPair}
+          />
+        </Modal>
+      )}
     </>
   );
 }

--- a/src/app/pages/Swap/index.tsx
+++ b/src/app/pages/Swap/index.tsx
@@ -27,9 +27,15 @@ import { getPoolByTags } from 'utils/spicy';
 import PoolChart from 'app/components/PoolChart';
 import { constructPair } from './util/pair';
 import { defaultPairList } from 'app/common/const';
+import {
+  LocalStorageService,
+  StorageKeys,
+} from 'app/services/local-storage-service';
 
 export function Swap() {
   const dispatch = useDispatch();
+  const storageService = new LocalStorageService();
+
   const { actions } = useSpicySwapSlice();
   const { actions: walletActions } = useWalletSlice();
 
@@ -67,8 +73,14 @@ export function Swap() {
   };
 
   useEffect(() => {
-    // When initial state does not contain tokens, call api to load tokens
+    const localTokenMetadata = storageService.getItem<SpicyToken[]>(
+      StorageKeys.tokenMetadata,
+    );
+
     if (tokens.length === 0) {
+      if (localTokenMetadata) {
+        dispatch(actions.setTokens(localTokenMetadata));
+      }
       dispatch(actions.loadTokens());
     }
   }, [dispatch, actions]);
@@ -79,14 +91,6 @@ export function Swap() {
       dispatch(actions.loadPools());
     }
   }, [dispatch, actions]);
-
-  useEffect(() => {
-    const constructedPair = constructPair(defaultPairList, tokens);
-
-    if (!pair && tokens.length) {
-      dispatch(actions.setPair(constructedPair));
-    }
-  }, [tokens, pair, dispatch, actions]);
 
   useEffect(() => {
     if (pools.length && pair && pair.from && pair.to) {

--- a/src/app/pages/Swap/slice/index.ts
+++ b/src/app/pages/Swap/slice/index.ts
@@ -6,6 +6,7 @@ import { SpicySwapState, SpicySwapErrorType } from './types';
 import { SpicyToken } from 'types/SpicyToken';
 import { SwapPair } from 'types/Swap';
 import { SpicyPool, SpicyPoolMetric } from 'types/SpicyPool';
+import { defaultFrom } from 'app/common/const';
 
 export const initialState: SpicySwapState = {
   tokens: [],
@@ -17,6 +18,7 @@ export const initialState: SpicySwapState = {
   fromAmountUsd: 0,
   toAmount: 0,
   toAmountUsd: 0,
+  pair: { from: defaultFrom },
 };
 
 const slice = createSlice({
@@ -55,6 +57,9 @@ const slice = createSlice({
     },
     poolMetricsError(state, action: PayloadAction<SpicySwapErrorType>) {
       state.error = action.payload;
+    },
+    setTokens(state, action: PayloadAction<SpicyToken[]>) {
+      state.tokens = action.payload;
     },
     loadTokens(state) {
       state.loading = true;

--- a/src/app/pages/Swap/slice/saga.ts
+++ b/src/app/pages/Swap/slice/saga.ts
@@ -4,8 +4,13 @@ import { spicySwapActions as actions } from '.';
 import { GetPoolProps, GetTokenProps, SpicySwapErrorType } from './types';
 import { calculateDayAgg, calculateHourAgg } from 'utils/spicy';
 import { transformPoolMetrics, transformPools, transformTokens } from './util';
+import {
+  LocalStorageService,
+  StorageKeys,
+} from 'app/services/local-storage-service';
 
 const SPICY_API = 'https://spicyb.sdaotools.xyz/api/rest';
+const storageService = new LocalStorageService();
 
 export function* getTokens({ transformTokens }: GetTokenProps) {
   const requestURL = `${SPICY_API}/TokenList?day_agg_start=${calculateDayAgg()}`;
@@ -17,6 +22,8 @@ export function* getTokens({ transformTokens }: GetTokenProps) {
     if (tokens?.length > 0) {
       const transformedTokens = transformTokens(tokens);
       yield put(actions.tokensLoaded(transformedTokens));
+
+      storageService.setItem(StorageKeys.tokenMetadata, transformedTokens);
     } else {
       yield put(actions.tokensError(SpicySwapErrorType.TOKEN_NOT_FOUND));
     }

--- a/src/app/pages/Swap/slice/types.ts
+++ b/src/app/pages/Swap/slice/types.ts
@@ -11,8 +11,8 @@ export interface SpicySwapState {
   tokens: SpicyToken[];
   pools: SpicyPool[];
   poolMetrics: SpicyPoolMetric[] | null;
-  fromAmount?: number;
-  toAmount?: number;
+  fromAmount: number;
+  toAmount: number;
   fromAmountUsd?: number;
   toAmountUsd?: number;
   pair?: SwapPair;

--- a/src/app/pages/Swap/util/pair.ts
+++ b/src/app/pages/Swap/util/pair.ts
@@ -1,8 +1,7 @@
 import { getTokenByTag } from 'utils/spicy';
 
 export const constructPair = (tags, tokenList) => {
-  return Object.assign(
-    {},
+  const pair = {
     ...tags.map((tag, index) => {
       const token = getTokenByTag(tokenList, tag);
       return {
@@ -14,5 +13,7 @@ export const constructPair = (tags, tokenList) => {
         }),
       };
     }),
-  );
+  };
+
+  return Object.assign({}, pair);
 };

--- a/src/app/pages/Swap/util/price.ts
+++ b/src/app/pages/Swap/util/price.ts
@@ -1,3 +1,10 @@
+import { SwapPair } from 'types/Swap';
+
+type SwapAmountParameters = {
+  pair: SwapPair;
+  fromAmount: number;
+};
+
 type QuoteParameters = {
   tokenFromReserve: number;
   tokenToReserve: number;
@@ -5,25 +12,62 @@ type QuoteParameters = {
   tradeFee?: number;
 };
 
+interface QuoteResponse {
+  toAmount: number;
+  priceImpact: number;
+}
+
 export const getSwapQuote = ({
   tokenFromReserve,
   tokenToReserve,
   tokenFromAmount,
   tradeFee = 0.003,
-}: QuoteParameters) => {
+}: QuoteParameters): QuoteResponse => {
   if (tokenFromReserve < 0 || tokenToReserve < 0 || tokenFromAmount < 0) {
     throw new Error('Reserves and amounts must be non-negative');
   }
 
   const token1AmountAfterFee = tokenFromAmount * (1 - tradeFee);
   const newToken1Reserve = tokenFromReserve + token1AmountAfterFee;
+
   const newToken2Reserve =
     (tokenFromReserve * tokenToReserve) / newToken1Reserve;
+
   const token2Amount = tokenToReserve - newToken2Reserve;
 
   if (token2Amount < 0) {
     throw new Error('Calculated token2Amount is negative');
   }
 
-  return token2Amount;
+  const priceBeforeTrade = tokenToReserve / tokenFromReserve;
+  const priceAfterTrade = newToken2Reserve / newToken1Reserve;
+
+  const priceImpact =
+    ((priceAfterTrade - priceBeforeTrade) / priceBeforeTrade) * 100;
+
+  return {
+    toAmount: token2Amount,
+    priceImpact,
+  };
+};
+
+export const getSwapAmount = ({ pair, fromAmount }: SwapAmountParameters) => {
+  const tokenFrom =
+    pair.pool?.fromToken.tag === pair.from?.tag
+      ? pair.pool?.fromToken
+      : pair.pool?.toToken;
+
+  const tokenTo =
+    pair.pool?.toToken.tag === pair.to?.tag
+      ? pair.pool?.toToken
+      : pair.pool?.fromToken;
+
+  const tokenFromReserve = Number(tokenFrom?.reserve);
+  const tokenToReserve = Number(tokenTo?.reserve);
+
+  return getSwapQuote({
+    tokenFromReserve,
+    tokenToReserve,
+    tokenFromAmount: fromAmount,
+  });
 };

--- a/src/app/services/local-storage-service.ts
+++ b/src/app/services/local-storage-service.ts
@@ -1,0 +1,21 @@
+export enum StorageKeys {
+  tokenMetadata = 'tokenMetadata',
+  swapPair = 'swapPair',
+  userSettings = 'userSettings',
+}
+
+export class LocalStorageService {
+  public setItem(key: StorageKeys, value: any): void {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+
+  public getItem<T>(key: StorageKeys): T | null {
+    const data: string | null = localStorage.getItem(key);
+
+    if (data !== null) {
+      return JSON.parse(data);
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Page would flicker & have a 1-1.5 second delay before the token list was loaded and the widget populated with useful information.

This change introduces a few improvements to get the swap widget loaded immediately, along with a default pair. By the time the user clicks on anything else, it should already be loaded.