### PR TITLE
feat: support switching pairs using button

### DIFF
--- a/src/app/pages/Swap/components/SwapSelection/SwapSelection.ts
+++ b/src/app/pages/Swap/components/SwapSelection/SwapSelection.ts
@@ -55,6 +55,7 @@ export const SwapSelectionAsset = styled.div`
   align-items: center;
   border-radius: 5px;
   min-width: 60px;
+  user-select: none;
 `;
 
 export const Subtext = styled(P)`

--- a/src/app/pages/Swap/components/SwapSelection/index.tsx
+++ b/src/app/pages/Swap/components/SwapSelection/index.tsx
@@ -16,6 +16,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectFromAmount, selectToAmount } from '../../slice/selectors';
 import { ChangeEvent, useEffect } from 'react';
 import { getSwapAmount } from '../../util/price';
+import { switchPairDirection } from '../../util/pair';
 interface SwapAssetSelectionProps {
   toggleModal: (dir?: SwapDirection) => void;
   pair?: SwapPair;
@@ -35,6 +36,13 @@ export function SwapAssetSelection({
 
   const handleTokenClick = (dir: SwapDirection) => {
     toggleModal(dir);
+  };
+
+  const handlePairSwitch = () => {
+    if (pair) {
+      const pairSwitched = switchPairDirection(pair);
+      dispatch(actions.setPair(pairSwitched));
+    }
   };
 
   const formatAmount = (value: number | undefined) => (value ? value : '');
@@ -91,7 +99,9 @@ export function SwapAssetSelection({
           placeholder="0.00000000"
         />
       </SwapSelection>
-      {showSwitch ? <SwapSelectionScrollIcon /> : null}
+      {showSwitch ? (
+        <SwapSelectionScrollIcon onClick={handlePairSwitch} />
+      ) : null}
       <SwapSelection>
         <Subtext>To</Subtext>
         <A

--- a/src/app/pages/Swap/util/pair.ts
+++ b/src/app/pages/Swap/util/pair.ts
@@ -17,3 +17,11 @@ export const constructPair = (tags, tokenList) => {
 
   return Object.assign({}, pair);
 };
+
+export const switchPairDirection = pair => {
+  return {
+    ...pair,
+    from: pair.to,
+    to: pair.from,
+  };
+};


### PR DESCRIPTION
## Description

Allows the user to switch the direction of the pair (WTZ_USDT -> USDT_WTZ) using the "switch" icon on the widget.